### PR TITLE
Fix mixed content warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site
 title: MWR InfoSecurity - Mobile Tools
 description: Drozer and Needle - Mobile Security Blog
-url: http://mobiletools.mwrinfosecurity.com
+url: https://mobiletools.mwrinfosecurity.com
 logo: images/android.png                                       # Site logo
 locale: en_US
 


### PR DESCRIPTION
Currently there are many mixed content warnings for plain HTTP links generated from the {{site.url}} template variable.